### PR TITLE
Kill process in case of Timeout

### DIFF
--- a/programl/create_ops.py
+++ b/programl/create_ops.py
@@ -268,6 +268,7 @@ def from_clang(
         try:
             stdout, stderr = process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired as e:
+            process.kill()
             raise TimeoutError(str(e)) from e
 
         return _graph_from_subprocess(process, stdout, stderr)


### PR DESCRIPTION
https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate

"The child process is not killed if the timeout expires, so in order to cleanup properly a well-behaved application should kill the child process and finish communication"

Indeed, many subsequent timeout errors fill the RAM extremely fast.
